### PR TITLE
Repair dependencies of camel-core-osgi and deployment of camel-test-scr

### DIFF
--- a/core/camel-core-osgi/pom.xml
+++ b/core/camel-core-osgi/pom.xml
@@ -37,6 +37,7 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core-engine</artifactId>
             <version>${camel.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
@@ -59,21 +60,21 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.9</version>
+                <version>${maven-bundle-plugin-version}</version>
                 <extensions>true</extensions>
                 <inherited>true</inherited>
                 <configuration>
                     <instructions>
                         <Export-Package>
-                            org.apache.camel*
+                            org.apache.camel.karaf.core*
                         </Export-Package>
                         <Import-Package>
                             org.osgi.service.event;resolution:=optional,
                             *
                         </Import-Package>
                         <Provide-Capability>
-                            osgi.extender; osgi.extender="org.apache.camel"; uses:="org.apache.camel.core.osgi.impl";
-                            version:Version="$(version;==;4.3.0)"
+                            osgi.extender; osgi.extender="org.apache.camel"; uses:="org.apache.camel.karaf.core";
+                            version:Version="$(version;==;4.4.0)"
                         </Provide-Capability>
                         <Bundle-Activator>org.apache.camel.karaf.core.Activator</Bundle-Activator>
                     </instructions>

--- a/core/camel-xml-jaxp/pom.xml
+++ b/core/camel-xml-jaxp/pom.xml
@@ -53,6 +53,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-xml-jaxp-util</artifactId>
+            <version>${camel.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -70,6 +81,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>org.apache.camel:camel-xml-jaxp</include>
+                                    <include>org.apache.camel:camel-xml-jaxp-util</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/tests/camel-test-scr/pom.xml
+++ b/tests/camel-test-scr/pom.xml
@@ -40,6 +40,21 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel.karaf</groupId>
+            <artifactId>camel-core-model</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.karaf</groupId>
+            <artifactId>camel-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core-engine</artifactId>
+            <version>${camel.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
@@ -69,8 +84,6 @@
                             org.apache.camel.karaf.test
                         </Export-Package>
                         <Import-Package>
-                            !org.apache.camel.karaf.test,
-                            org.osgi.service.component*,
                             *
                         </Import-Package>
                     </instructions>

--- a/tests/camel-test-scr/src/main/java/org/apache/camel/karaf/test/CamelComponent.java
+++ b/tests/camel-test-scr/src/main/java/org/apache/camel/karaf/test/CamelComponent.java
@@ -21,6 +21,7 @@ import org.apache.camel.karaf.core.OsgiClassResolver;
 import org.apache.camel.karaf.core.OsgiDataFormatResolver;
 import org.apache.camel.karaf.core.OsgiDefaultCamelContext;
 import org.apache.camel.karaf.core.OsgiLanguageResolver;
+import org.apache.camel.karaf.core.OsgiFactoryFinder;
 import org.apache.camel.model.ModelCamelContext;
 import org.apache.camel.spi.DataFormatResolver;
 import org.apache.camel.spi.LanguageResolver;
@@ -46,10 +47,12 @@ public class CamelComponent {
     public void activate(ComponentContext componentContext) throws Exception {
         BundleContext bundleContext = componentContext.getBundleContext();
         OsgiDefaultCamelContext osgiDefaultCamelContext = new OsgiDefaultCamelContext(bundleContext);
-        osgiDefaultCamelContext.setClassResolver(new OsgiClassResolver(camelContext, bundleContext));
+        OsgiClassResolver resolver =  new OsgiClassResolver(camelContext, bundleContext);
+        osgiDefaultCamelContext.setClassResolver(resolver);
         osgiDefaultCamelContext.getCamelContextExtension().addContextPlugin(DataFormatResolver.class, new OsgiDataFormatResolver(bundleContext));
         osgiDefaultCamelContext.getCamelContextExtension().addContextPlugin(LanguageResolver.class, new OsgiLanguageResolver(bundleContext));
         osgiDefaultCamelContext.getCamelContextExtension().setName("context-test");
+        osgiDefaultCamelContext.getCamelContextExtension().setBootstrapFactoryFinder(new OsgiFactoryFinder(bundleContext,resolver,"META-INF/services/org/apache/camel/"));
         camelContext = osgiDefaultCamelContext;
         serviceRegistration = bundleContext.registerService(CamelContext.class, camelContext, null);
         camelContext.start();


### PR DESCRIPTION
In order to be able to deploy the camel-test-scr into karaf 4.4.4 , the following changes were necessary : 
- camel-core-osgi contains all camel core classes instead of  org.apache.camel.karaf.core.* classes  (it also reduces drastically the size of the bundle )
- camel-xml-jaxp has a new dependency caml-xml-jaxp-util that I added in the same bundle
- set the boostrap factory finder in the test setup to uses OSGI class loader and avoid ClassNotFoundException

After installation of camel-core and scr features, then camel-test-scr-4.4.0-SNAPSHOT.jar , test is OK :

`8:12:33.998 INFO [Camel (camel-1) thread #1 - timer://fire] [TEST] Body: Hello World
18:12:33.999 INFO [Camel (camel-1) thread #1 - timer://fire] [INNER TEST] Route consuming from direct endpoint received: Hello World
18:12:35.534 INFO [CM Configuration Updater (Update: pid=org.ops4j.pax.logging)] Sending Event Admin notification (configuration successful) to org/ops4j/pax/logging/Configuration`