### PR TITLE
Add camel-mongodb and camel-mongodb-gridfs wrapper

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1542,26 +1542,22 @@
 <!--        <feature version='${project.version}'>camel-core</feature>-->
 <!--        <bundle>mvn:org.apache.camel/camel-mllp/${project.version}</bundle>-->
 <!--    </feature>-->
-<!--    <feature name='camel-mongodb' version='${project.version}' start-level='50'>-->
-<!--        <feature version='${project.version}'>camel-core</feature>-->
-<!--        <feature version='${project.version}'>camel-jackson</feature>-->
-<!--        <bundle dependency='true'>mvn:org.mongodb/bson/${mongo-java-driver-version}</bundle>-->
-<!--        <feature prerequisite='true'>wrap</feature>-->
-<!--        &lt;!&ndash; Temporary workaround to fix https://jira.mongodb.org/browse/JAVA-4789, won't be needed once 4.8.0 will be released &ndash;&gt;-->
-<!--        <bundle dependency='true'>wrap:mvn:org.mongodb/mongodb-driver-core/${mongo-java-driver-version}$overwrite=merge&amp;Import-Package=*;resolution:=optional</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-sync/${mongo-java-driver-version}</bundle>-->
-<!--        <bundle>mvn:org.apache.camel/camel-mongodb/${project.version}</bundle>-->
-<!--    </feature>-->
-<!--    <feature name='camel-mongodb-gridfs' version='${project.version}' start-level='50'>-->
-<!--        <feature version='${project.version}'>camel-core</feature>-->
-<!--        <feature version='${project.version}'>camel-jackson</feature>-->
-<!--        <bundle dependency='true'>mvn:org.mongodb/bson/${mongo-java-driver-version}</bundle>-->
-<!--        <feature prerequisite='true'>wrap</feature>-->
-<!--        &lt;!&ndash; Temporary workaround to fix https://jira.mongodb.org/browse/JAVA-4789, won't be needed once 4.8.0 will be released &ndash;&gt;-->
-<!--        <bundle dependency='true'>wrap:mvn:org.mongodb/mongodb-driver-core/${mongo-java-driver-version}$overwrite=merge&amp;Import-Package=*;resolution:=optional</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-sync/${mongo-java-driver-version}</bundle>-->
-<!--        <bundle>mvn:org.apache.camel/camel-mongodb-gridfs/${project.version}</bundle>-->
-<!--    </feature>-->
+    <feature name='camel-mongodb' version='${project.version}' start-level='50'>
+            <feature version='${project.version}'>camel-core</feature>
+            <feature version='${project.version}'>camel-jackson</feature>
+            <bundle dependency='true'>mvn:org.mongodb/bson/${mongo-java-driver-version}</bundle>
+            <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-core/${mongo-java-driver-version}</bundle>
+            <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-sync/${mongo-java-driver-version}</bundle>
+            <bundle>mvn:org.apache.camel.karaf/camel-mongodb/${project.version}</bundle>
+    </feature>
+    <feature name='camel-mongodb-gridfs' version='${project.version}' start-level='50'>
+        <feature version='${project.version}'>camel-core</feature>
+        <feature version='${project.version}'>camel-jackson</feature>
+        <bundle dependency='true'>mvn:org.mongodb/bson/${mongo-java-driver-version}</bundle>
+        <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-core/${mongo-java-driver-version}</bundle>
+        <bundle dependency='true'>mvn:org.mongodb/mongodb-driver-sync/${mongo-java-driver-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-mongodb-gridfs/${project.version}</bundle>
+    </feature>
 <!--    <feature name='camel-mustache' version='${project.version}' start-level='50'>-->
 <!--        <feature version='${project.version}'>camel-core</feature>-->
 <!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.mustache-compiler/${mustache-bundle-version}</bundle>-->

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@
         <maven-shade-plugin-version>3.5.1</maven-shade-plugin-version>
         <maven-bundle-plugin-version>5.1.9</maven-bundle-plugin-version>
         <maven-compiler-plugin-version>3.11.0</maven-compiler-plugin-version>
+        <mongo-java-driver-version>4.11.1</mongo-java-driver-version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Add camel-mongodb and camel-mongodb-gridfs wrapper.
Wrap workaround is  not necessary anymore when using 4.11.1 version of driver