### PR TITLE
Added camel-ftp component integration test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,6 +566,8 @@
         <mongo-java-driver-version>4.11.1</mongo-java-driver-version>
         <velocity-version>2.3</velocity-version>
         <bouncycastle-version>1.77</bouncycastle-version>
+        <jackson-version>2.16.2</jackson-version>
+        <testcontainers-version>1.19.7</testcontainers-version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/tests/camel-integration-test/pom.xml
+++ b/tests/camel-integration-test/pom.xml
@@ -89,7 +89,7 @@
                             org.rnorth.ducttape*
                         </Export-Package>
                         <Import-Package>
-                            org.apache.karaf.itests,org.ops4j.pax.exam,org.osgi.framework,org.junit,
+                            org.apache.karaf.itests,org.ops4j.pax.exam,org.osgi.framework,org.junit*,
                             org.apache.camel*;${camel.osgi.import.camel.version},
                             org.osgi.service.*,
                             org.slf4j*,

--- a/tests/camel-integration-test/pom.xml
+++ b/tests/camel-integration-test/pom.xml
@@ -46,6 +46,17 @@
                 <version>${karaf.version}</version>
                 <scope>compile</scope>
             </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${testcontainers-version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson-version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -71,13 +82,25 @@
                 <configuration>
                     <instructions>
                         <Export-Package>
-                            org.apache.karaf.camel.itests;version=${camel.version}
+                            org.apache.karaf.camel.itests;version=${camel.version},
+                            !org.testcontainers.shaded*,
+                            org.testcontainers*,
+                            com.github.dockerjava*,
+                            org.rnorth.ducttape*
                         </Export-Package>
                         <Import-Package>
                             org.apache.karaf.itests,org.ops4j.pax.exam,org.osgi.framework,org.junit,
                             org.apache.camel*;${camel.osgi.import.camel.version},
-                            org.osgi.service.*
+                            org.osgi.service.*,
+                            org.slf4j*,
+                            javax.net,
+                            javax.net.ssl*,
+                            org.w3c.dom*
                         </Import-Package>
+                        <Private-Package>
+                            org.testcontainers.shaded*,
+                            com.fasterxml.jackson*
+                        </Private-Package>
                     </instructions>
                     <excludeDependencies>geronimo-atinject_1.0_spec</excludeDependencies>
                 </configuration>
@@ -158,6 +181,14 @@
             <artifactId>camel-base-engine</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/AbstractCamelComponent.java
+++ b/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/AbstractCamelComponent.java
@@ -36,6 +36,7 @@ public abstract class AbstractCamelComponent {
 
     @Activate
     public void activate(ComponentContext componentContext) throws Exception {
+        setupResources(componentContext);
         BundleContext bundleContext = componentContext.getBundleContext();
         OsgiDefaultCamelContext osgiDefaultCamelContext = new OsgiDefaultCamelContext(bundleContext);
         OsgiClassResolver resolver =  new OsgiClassResolver(camelContext, bundleContext);
@@ -54,8 +55,17 @@ public abstract class AbstractCamelComponent {
         camelContext.stop();
         camelContext.removeRouteDefinitions(new ArrayList<RouteDefinition>(camelContext.getRouteDefinitions()));
         serviceRegistration.unregister();
+        tearDownResources();
     }
 
 
     protected abstract RouteBuilder createRouteBuilder();
+
+    protected void setupResources(ComponentContext context) {
+        return;
+    }
+
+    protected void tearDownResources() {
+        return;
+    }
 }

--- a/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/CamelKarafITest.java
+++ b/tests/camel-integration-test/src/main/java/org/apache/karaf/camel/itests/CamelKarafITest.java
@@ -73,6 +73,7 @@ public class CamelKarafITest extends KarafTestSupport {
                 KarafDistributionOption.editConfigurationFileExtend("etc/system.properties", "project.target", getBaseDir()),
                 KarafDistributionOption.features("mvn:org.apache.camel.karaf/apache-camel/"+ getVersion() + "/xml/features", "scr","camel-core"),
                 CoreOptions.mavenBundle().groupId("org.apache.camel.karaf").artifactId("camel-integration-test").versionAsInProject(),
+                KarafDistributionOption.debugConfiguration("5005",false),
         };
         return Stream.of(super.config(), options).flatMap(Stream::of).toArray(Option[]::new);
     }

--- a/tests/components/camel-ftp/pom.xml
+++ b/tests/components/camel-ftp/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.camel.karaf</groupId>
+        <artifactId>camel-karaf-components-test</artifactId>
+        <version>4.4.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>camel-ftp-test</artifactId>
+    <name>Apache Camel :: Karaf :: Tests :: Components :: FTP</name>
+
+
+</project>

--- a/tests/components/camel-ftp/pom.xml
+++ b/tests/components/camel-ftp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.apache.camel.karaf</groupId>
         <artifactId>camel-karaf-components-test</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/components/camel-ftp/src/main/java/org/apache/karaf/camel/test/CamelFtpComponent.java
+++ b/tests/components/camel-ftp/src/main/java/org/apache/karaf/camel/test/CamelFtpComponent.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.karaf.camel.test;
+
+import java.io.IOException;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.karaf.camel.itests.AbstractCamelComponent;
+import org.osgi.framework.wiring.BundleWiring;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Component;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+
+@Component(name = "karaf-camel-ftp-test", immediate = true)
+public class CamelFtpComponent extends AbstractCamelComponent {
+
+    private FixedHostPortGenericContainer ftpContainer;
+
+    private static final String FTP_USERNAME = "user";
+    private static final String FTP_PASSWORD = "password";
+    private static final String FTP_DIRECTORY = "/home/user/dir";
+
+    private static final int PORT = 21;
+    private static final String USER = "user";
+    private static final String PASSWORD = "password";
+
+    private static final int PASSIVE_MODE_PORT = 21100;
+
+    @Override
+    protected void setupResources(ComponentContext context) {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread()
+                    .setContextClassLoader(context.getBundleContext().getBundle().adapt(BundleWiring.class).getClassLoader());
+            ftpContainer = new FixedHostPortGenericContainer<>("delfer/alpine-ftp-server:latest").withFixedExposedPort(PORT, PORT)
+                    .withFixedExposedPort(PASSIVE_MODE_PORT, PASSIVE_MODE_PORT)
+                    .withFixedExposedPort(PASSIVE_MODE_PORT + 1, PASSIVE_MODE_PORT + 1)
+                    .withFixedExposedPort(PASSIVE_MODE_PORT + 2, PASSIVE_MODE_PORT + 2)
+                    .withEnv("USERS", USER + "|" + PASSWORD + "|" + FTP_DIRECTORY)
+                    .withEnv("MIN_PORT", String.valueOf(PASSIVE_MODE_PORT))
+                    .withEnv("MAX_PORT", String.valueOf(PASSIVE_MODE_PORT + 2))
+                    .withEnv("PUBLICHOST", "localhost")
+                    .withEnv("FTP_USER_NAME", FTP_USERNAME)
+                    .withEnv("FTP_USER_PASS", FTP_PASSWORD)
+                    .withEnv("FTP_USER_HOME", FTP_DIRECTORY);
+            ftpContainer.start();
+            System.out.println(ftpContainer.execInContainer("/bin/touch", FTP_DIRECTORY + "/testFtp.txt"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            throw e;
+        } finally {
+            Thread.currentThread().setContextClassLoader(cl);
+        }
+    }
+
+    @Override
+    protected void tearDownResources() {
+        ftpContainer.stop();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+
+            @Override
+            public void configure() throws Exception {
+                from("ftp://localhost/?username=user&password=password&binary=true&passiveMode=true&delay=1000").to(
+                        "file:" + System.getProperty("project.target"));
+            }
+        };
+    }
+}

--- a/tests/components/camel-ftp/src/test/java/org/apache/karaf/camel/itests/CamelFtpITest.java
+++ b/tests/components/camel-ftp/src/test/java/org/apache/karaf/camel/itests/CamelFtpITest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.karaf.camel.itests;
+
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class CamelFtpITest extends CamelKarafITest {
+
+    @Test
+    public void testFtpComponent() throws Exception {
+
+        installAndAssertFeature("camel-ftp");
+        installBundle("file://" + getBaseDir() + "/camel-ftp-test-" + getVersion() + ".jar", true);
+        assertBundleInstalled("camel-ftp-test");
+        assertBundleInstalledAndRunning("camel-ftp-test");
+
+        Path filePath = Path.of(getBaseDir(), "testFtp.txt");
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> Files.exists(filePath));
+        assertTrue(Files.exists(filePath));
+    }
+}

--- a/tests/components/pom.xml
+++ b/tests/components/pom.xml
@@ -35,6 +35,7 @@
     <modules>
         <module>camel-file</module>
         <module>camel-seda</module>
+        <module>camel-ftp</module>
     </modules>
 
     <dependencyManagement>
@@ -146,6 +147,12 @@
             <artifactId>org.apache.servicemix.bundles.hamcrest</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -175,6 +182,7 @@
                         </Export-Package>
                         <Import-Package>
                             org.apache.camel*;${camel.osgi.import.camel.version},
+                            org.testcontainers.dockerclient,
                             *
                         </Import-Package>
                     </instructions>


### PR DESCRIPTION
Added a camel ftp integration test using testcontainers (used FixedHostPortGenericContainer and [delfer/alpine-ftp-server](https://hub.docker.com/r/delfer/alpine-ftp-server/) image). For classloading reason, the container is started from the camel-ftp-test bundle and not from the RBC bundle. 
In the test the file is created on the container and then copied to the target folder using camel route (from ftp to a file)