### PR TITLE
Add camel-karaf-xslt-saxon wrapper

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -2161,12 +2161,11 @@
         <bundle dependency='true'>wrap:mvn:xpp3/xpp3/1.1.4c</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-xmpp/${project.version}</bundle>
     </feature>
-<!--    <feature name='camel-xslt-saxon' version='${project.version}' start-level='50'>-->
-<!--        <feature version='${project.version}'>camel-core</feature>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/${xmlresolver-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.saxon/${saxon-bundle-version}</bundle>-->
-<!--        <bundle>mvn:org.apache.camel/camel-xslt-saxon/${project.version}</bundle>-->
-<!--    </feature>-->
+    <feature name='camel-xslt-saxon' version='${project.version}' start-level='50'>
+        <feature version='${project.version}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:net.sf.saxon/Saxon-HE/12.4</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-xslt-saxon/${project.version}</bundle>
+    </feature>
 <!--    <feature name='camel-xstream' version='${project.version}' start-level='50'>-->
 <!--        <feature version='${project.version}'>camel-core</feature>-->
 <!--        <bundle dependency='true'>mvn:org.codehaus.jettison/jettison/${jettison-version}</bundle>-->

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -2163,7 +2163,7 @@
     </feature>
     <feature name='camel-xslt-saxon' version='${project.version}' start-level='50'>
         <feature version='${project.version}'>camel-core</feature>
-        <bundle dependency='true'>wrap:mvn:net.sf.saxon/Saxon-HE/12.4</bundle>
+        <bundle dependency='true'>wrap:mvn:net.sf.saxon/Saxon-HE/${saxon-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-xslt-saxon/${project.version}</bundle>
     </feature>
 <!--    <feature name='camel-xstream' version='${project.version}' start-level='50'>-->


### PR DESCRIPTION
Did not include dependency
`bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.saxon/${saxon-bundle-version}</bundle>`
Which apparently can be replaced with
`<bundle dependency='true'>wrap:mvn:org.xmlresolver/xmlresolver/5.2.2</bundle>`
We may need it as the feature is identical to camel-saxon now, but now leaving it as is, as discussed, since able to build without it