### PR TITLE
Add camel-djl wrapper

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -743,15 +743,11 @@
         <bundle dependency='true'>mvn:com.lmax/disruptor/3.4.4</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-disruptor/${project.version}</bundle>
     </feature>
-<!--    <feature name='camel-djl' version='${project.version}' start-level='50'>-->
-<!--        <feature version='${project.version}'>camel-core</feature>-->
-<!--        <bundle dependency='true'>wrap:mvn:ai.djl/api/${djl-version}</bundle>-->
-<!--        <bundle dependency='true'>wrap:mvn:ai.djl/model-zoo/${djl-version}</bundle>-->
-<!--        <bundle dependency='true'>wrap:mvn:ai.djl.mxnet/mxnet-model-zoo/${djl-version}</bundle>-->
-<!--        <bundle dependency='true'>wrap:mvn:ai.djl.mxnet/mxnet-engine/${djl-version}</bundle>-->
-<!--        <bundle dependency='true'>wrap:mvn:ai.djl.mxnet/mxnet-native-auto/${djl-mxnet-native-version}</bundle>-->
-<!--        <bundle>mvn:org.apache.camel/camel-djl/${project.version}</bundle>-->
-<!--    </feature>-->
+    <feature name='camel-djl' version='${project.version}' start-level='50'>
+        <feature version='${project.version}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:ai.djl/api/0.26.0</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-djl/${project.version}</bundle>
+    </feature>
     <feature name='camel-dns' version='${project.version}' start-level='50'>
         <feature version='${project.version}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:dnsjava/dnsjava/3.5.3</bundle>


### PR DESCRIPTION
Only `ai.djl/api` turned out to be required on build time