### PR TITLE
Add camel-micrometer wrapper

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1277,14 +1277,17 @@
         <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-json/4.2.25</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-metrics/${project.version}</bundle>
     </feature>
-<!--    <feature name='camel-micrometer' version='${project.version}' start-level='50'>-->
-<!--        <feature version='${project.version}'>camel-core</feature>-->
-<!--        <bundle dependency='true'>wrap:mvn:io.micrometer/micrometer-core/${micrometer-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-version}</bundle>-->
-<!--        <bundle>mvn:org.apache.camel/camel-micrometer/${project.version}</bundle>-->
-<!--    </feature>-->
+    <feature name='camel-micrometer' version='${project.version}' start-level='50'>
+        <feature version='${project.version}'>camel-core</feature>
+        <feature>jackson</feature>
+        <bundle dependency='true'>wrap:mvn:io.micrometer/micrometer-core/${micrometer-version}$overwrite=merge&amp;Import-Package=*;resolution:=optional</bundle>
+        <bundle dependency='true'>wrap:mvn:io.micrometer/micrometer-commons/${micrometer-version}</bundle>
+        <bundle dependency='true'>mvn:io.micrometer/micrometer-registry-jmx/${micrometer-version}</bundle>
+        <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-core/4.2.25</bundle>
+        <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-jmx/4.2.25</bundle>
+        <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-json/4.2.25</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-micrometer/${project.version}</bundle>
+    </feature>
     <feature name='camel-mina' version='${project.version}' start-level='50'>
         <feature version='${project.version}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.mina/mina-core/2.2.2</bundle>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1281,7 +1281,7 @@
         <feature version='${project.version}'>camel-core</feature>
         <feature>jackson</feature>
         <bundle dependency='true'>wrap:mvn:io.micrometer/micrometer-core/${micrometer-version}$overwrite=merge&amp;Import-Package=*;resolution:=optional</bundle>
-        <bundle dependency='true'>wrap:mvn:io.micrometer/micrometer-commons/${micrometer-version}</bundle>
+        <bundle dependency='true'>mvn:io.micrometer/micrometer-commons/${micrometer-version}</bundle>
         <bundle dependency='true'>mvn:io.micrometer/micrometer-registry-jmx/${micrometer-version}</bundle>
         <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-core/4.2.25</bundle>
         <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-jmx/4.2.25</bundle>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1285,7 +1285,6 @@
         <bundle dependency='true'>mvn:io.micrometer/micrometer-registry-jmx/${micrometer-version}</bundle>
         <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-core/4.2.25</bundle>
         <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-jmx/4.2.25</bundle>
-        <bundle dependency='true'>mvn:io.dropwizard.metrics/metrics-json/4.2.25</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-micrometer/${project.version}</bundle>
     </feature>
     <feature name='camel-mina' version='${project.version}' start-level='50'>


### PR DESCRIPTION
Added `$overwrite=merge&amp;Import-Package=*;resolution:=optional` for micrometer-core to fix the `filter:="(&(osgi.wiring.package=javax.annotation)(version>=3.0.0)(!(version>=4.0.0)))"` error

The javax.annotation was resolved by updating micrometer to 1.12.4