### PR TITLE
Camel quickfix wrapper

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1589,14 +1589,12 @@
 <!--        <feature version='${camel.osgi.version.range}'>camel-core</feature>-->
 <!--        <bundle>mvn:org.apache.camel/camel-quartz/${project.version}</bundle>-->
 <!--    </feature>-->
-<!--    <feature name='camel-quickfix' version='${project.version}' start-level='50'>-->
-<!--        <feature version='${camel.osgi.version.range}'>camel-core</feature>-->
-<!--        <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/${xmlresolver-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.saxon/${saxon-bundle-version}</bundle>-->
-<!--        <bundle>mvn:org.quickfixj/quickfixj-all/${quickfixj-version}</bundle>-->
-<!--        <bundle>mvn:org.apache.camel/camel-quickfix/${project.version}</bundle>-->
-<!--    </feature>-->
+    <feature name='camel-quickfix' version='${project.version}' start-level='50'>
+        <feature>camel-saxon</feature>
+        <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina-version}</bundle>
+        <bundle>mvn:org.quickfixj/quickfixj-all/${quickfixj-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-quickfix/${project.version}</bundle>
+    </feature>
     <feature name='camel-spring-rabbitmq' version='${project.version}' start-level='50'>
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
         <feature version='${camel.osgi.spring.version}'>spring-tx</feature>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1590,7 +1590,8 @@
 <!--        <bundle>mvn:org.apache.camel/camel-quartz/${project.version}</bundle>-->
 <!--    </feature>-->
     <feature name='camel-quickfix' version='${project.version}' start-level='50'>
-        <feature>camel-saxon</feature>
+        <feature version='${project.version}'>camel-core</feature>
+        <bundle dependency="true">wrap:mvn:net.sf.saxon/Saxon-HE/12.4</bundle>
         <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina-version}</bundle>
         <bundle dependency='true'>mvn:org.quickfixj/quickfixj-all/${quickfixj-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-quickfix/${project.version}</bundle>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1591,9 +1591,9 @@
 <!--    </feature>-->
     <feature name='camel-quickfix' version='${project.version}' start-level='50'>
         <feature version='${project.version}'>camel-core</feature>
-        <bundle dependency="true">wrap:mvn:net.sf.saxon/Saxon-HE/12.4</bundle>
+        <bundle dependency='true'>mvn:org.quickfixj/quickfixj-core/${quickfixj-version}</bundle>
+        <bundle dependency='true'>mvn:org.quickfixj/quickfixj-messages-all/${quickfixj-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina-version}</bundle>
-        <bundle dependency='true'>mvn:org.quickfixj/quickfixj-all/${quickfixj-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-quickfix/${project.version}</bundle>
     </feature>
     <feature name='camel-spring-rabbitmq' version='${project.version}' start-level='50'>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1592,7 +1592,7 @@
     <feature name='camel-quickfix' version='${project.version}' start-level='50'>
         <feature>camel-saxon</feature>
         <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina-version}</bundle>
-        <bundle>mvn:org.quickfixj/quickfixj-all/${quickfixj-version}</bundle>
+        <bundle dependency='true'>mvn:org.quickfixj/quickfixj-all/${quickfixj-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-quickfix/${project.version}</bundle>
     </feature>
     <feature name='camel-spring-rabbitmq' version='${project.version}' start-level='50'>


### PR DESCRIPTION
used `camel-saxon` for camel and saxon dependencies, as it consists of that and nothing more