### PR TITLE
Add camel-fink wrapper

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -780,6 +780,14 @@
         <bundle dependency='true'>mvn:net.sf.flatpack/flatpack/4.0.18</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-flatpack/${project.version}</bundle>
     </feature>
+    <feature name='camel-flink' version='${project.version}' start-level='50'>
+        <feature version='${project.version}'>camel-core</feature>
+        <bundle>wrap:mvn:org.apache.flink/flink-java/${flink-version}</bundle>
+        <bundle>wrap:mvn:org.apache.flink/flink-streaming-java/${flink-version}</bundle>
+        <bundle>wrap:mvn:org.apache.flink/flink-runtime/${flink-version}</bundle>
+        <bundle>wrap:mvn:org.apache.flink/flink-core/${flink-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-flink/${project.version}</bundle>
+    </feature>
     <feature name='camel-fop' version='${project.version}' start-level='50'>
         <feature version='${project.version}'>camel-core</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.xmlgraphics/fop-core/${fop-version}</bundle>


### PR DESCRIPTION
camel-fink wrapper
```
 <bundle>wrap:mvn:org.apache.flink/flink-java/${flink-version}</bundle>
 <bundle>wrap:mvn:org.apache.flink/flink-streaming-java/${flink-version}</bundle>
```
are the only necessary dependencies to have the feature compile correctly , but adding runtime, core and streaming fix most of the optional dependencies created by the wrap: protocol