### PR TITLE
Add camel-redis wrapper

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1583,23 +1583,33 @@
         <bundle dependency='true'>mvn:io.projectreactor/reactor-core/${reactor-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-reactor/${project.version}</bundle>
     </feature>
-<!--    <feature name='camel-spring-redis' version='${project.version}' start-level='50'>-->
-<!--        <feature version='${project.version}'>camel-core</feature>-->
-<!--        <feature version='${spring-version-range}'>spring-tx</feature>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-data-redis/${spring-data-redis-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-data-commons/${spring-data-commons-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-data-keyvalue/${spring-data-keyvalue-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jedis/${jedis-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.commons/commons-pool2/${commons-pool2-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:io.netty/netty-transport/${netty-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:io.netty/netty-buffer/${netty-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:io.netty/netty-common/${netty-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:io.netty/netty-resolver/${netty-version}</bundle>-->
-<!--        <bundle>mvn:org.apache.camel/camel-spring-redis/${project.version}</bundle>-->
-<!--    </feature>-->
+    <feature name='camel-redis' version='${project.version}' start-level='50'>
+        <feature version='${project.version}'>camel-core</feature>
+        <feature>jackson</feature>
+        <feature>netty</feature>
+        <feature version='${spring.version}'>spring</feature>
+        <bundle dependency='true'>mvn:org.redisson/redisson/${redisson-version}</bundle>
+        <bundle dependency='true'>mvn:com.esotericsoftware/kryo/5.6.0</bundle>
+        <bundle dependency='true'>mvn:com.esotericsoftware/minlog/1.3.1</bundle>
+        <bundle dependency='true'>mvn:com.esotericsoftware/reflectasm/1.11.9</bundle>
+        <bundle dependency='true'>mvn:org.objenesis/objenesis/3.3</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${jackson2-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-resolver-dns/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-dns/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport-classes-epoll/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport-classes-kqueue/${netty-version}</bundle>
+        <bundle dependency='true'>mvn:io.netty.incubator/netty-incubator-transport-classes-io_uring/0.0.21.Final</bundle>
+        <bundle dependency='true'>mvn:io.reactivex.rxjava3/rxjava/3.1.6</bundle>
+        <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
+        <bundle dependency='true'>mvn:javax.cache/cache-api/${jcache-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.jodd/jodd-bean/5.1.6</bundle>
+        <bundle dependency='true'>mvn:net.bytebuddy/byte-buddy/${bytebuddy-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.jboss.marshalling/jboss-marshalling/2.0.11.Final</bundle>
+        <bundle dependency='true'>mvn:io.projectreactor/reactor-core/${reactor-version}</bundle>
+        <bundle dependency='true'>mvn:org.yaml/snakeyaml/${snakeyaml-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-redis/${project.version}</bundle>
+    </feature>
     <feature name='camel-rest-openapi' version='${project.version}' start-level='50'>
         <feature version='${project.version}'>camel-core</feature>
         <feature>jackson</feature>


### PR DESCRIPTION
camel-redis wrapper
the redisson jar brings a lot of dependencies, some are not shown in the camel pom,but are present in the Manifest and in the pom inside the jar , ex netty-incubator-transport-classes-io_uring,  spring ...
I took the option to add the bundles, the other option would be to remove them from the redisson manifest.