### PR TITLE
Add camel-spring-ldap wrapper

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1824,20 +1824,11 @@
         <feature version='${camel.osgi.spring.version}'>spring-jdbc</feature>
         <bundle>mvn:org.apache.camel.karaf/camel-spring-jdbc/${project.version}</bundle>
     </feature>
-<!--    <feature name='camel-spring-ldap' version='${project.version}' start-level='50'>-->
-<!--        <feature version='${camel.osgi.version.range}'>camel-core</feature>-->
-<!--        <feature>transaction</feature>-->
-<!--        <feature version='${camel.osgi.spring.version-range}'>spring</feature>-->
-<!--        <feature version='${camel.osgi.spring.version-range}'>spring-jdbc</feature>-->
-<!--        <feature version='${camel.osgi.spring.version-range}'>spring-tx</feature>-->
-<!--        <bundle dependency='true'>mvn:commons-lang/commons-lang/${commons-lang-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/${geronimo-jms-spec-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-ldap/${spring-ldap-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-batch-core/${spring-batch-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-batch-infrastructure/${spring-batch-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-data-commons/${spring-data-commons-bundle-version}</bundle>-->
-<!--        <bundle>mvn:org.apache.camel/camel-spring-ldap/${project.version}</bundle>-->
-<!--    </feature>-->
+    <feature name='camel-spring-ldap' version='${project.version}' start-level='50'>
+        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:org.springframework.ldap/spring-ldap-core/${spring-ldap-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-spring-ldap/${project.version}</bundle>
+    </feature>
     <feature name='camel-spring-redis' version='${project.version}' start-level='50'>
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
         <feature version='${camel.osgi.spring.version}'>spring-tx</feature>


### PR DESCRIPTION
Only `org.springframework.ldap/spring-ldap-core` was required to build the feature. 
Had to user wrap as that is a regular jar. 
No SMX bundle for corresponding version
the dependency tree suggests the version 3.2.1 but the parameter we already have is 3.2.2, so went with the parameter as it is newer