### PR TITLE
Add camel-spring-ws wrapper

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1854,23 +1854,15 @@
         <bundle dependency='true'>wrap:mvn:org.springframework.data/spring-data-redis/${spring-data-redis-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-spring-redis/${project.version}</bundle>
     </feature>
-<!--    <feature name='camel-spring-ws' version='${project.version}' start-level='50'>-->
-<!--        <feature>http</feature>-->
-<!--        <feature version='${camel.osgi.version.range}'>camel-xslt-saxon</feature>-->
-<!--        <feature version='${camel.osgi.spring.version-range}'>spring</feature>-->
-<!--        <feature version='${camel.osgi.spring.version-range}'>spring-jms</feature>-->
-<!--        <feature version='${camel.osgi.spring.version-range}'>spring-oxm</feature>-->
-<!--        <feature version='${camel.osgi.spring.version-range}'>spring-web</feature>-->
-<!--        <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/${geronimo-jms-spec-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.wsdl4j/${wsdl4j-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-ws-core/${spring-ws-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-ws-support/${spring-ws-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-ws-security/${spring-ws-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-xml/${spring-xml-bundle-version}</bundle>-->
-<!--        <bundle dependency='true'>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.3/${servicemix-specs-version}</bundle>-->
-<!--        <bundle>mvn:org.apache.camel/camel-attachments/${project.version}</bundle>-->
-<!--        <bundle>mvn:org.apache.camel/camel-spring-ws/${project.version}</bundle>-->
-<!--    </feature>-->
+    <feature name='camel-spring-ws' version='${project.version}' start-level='50'>
+        <feature version='${camel.osgi.version.range}'>camel-xslt-saxon</feature>
+        <feature version='${camel.osgi.spring.version}'>spring</feature>
+        <feature version="[6,7)">jakarta-servlet</feature>
+        <bundle dependency='true'>wrap:mvn:org.springframework.ws/spring-ws-core/${spring-ws-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.springframework.ws/spring-xml/${spring-ws-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.camel.karaf/camel-attachments/${project.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-spring-ws/${project.version}</bundle>
+    </feature>
     <feature name='camel-sql' version='${project.version}' start-level='50'>
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
         <feature version='${camel.osgi.spring.version}'>spring-tx</feature>


### PR DESCRIPTION
Used `org.springframework.ws` with wrap since no SMX bundle for appropriate version is present (4.0.10 vs [4.0.9_1](https://mvnrepository.com/artifact/org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-ws-core/4.0.9_1))
