### PR TITLE
Add camel-jfr wrapper

### DIFF
--- a/components/camel-jfr/pom.xml
+++ b/components/camel-jfr/pom.xml
@@ -37,6 +37,7 @@
             org.apache.camel*;version=${camel.version}
         </camel.osgi.export>
         <camel.osgi.import>
+            !jdk.jfr,
             *
         </camel.osgi.import>
     </properties>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1146,6 +1146,10 @@
         <bundle>mvn:org.apache.camel.karaf/camel-jetty-common/${project.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jetty/${project.version}</bundle>
     </feature>
+    <feature name='camel-jfr' version='${project.version}' start-level='50'>
+        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <bundle>mvn:org.apache.camel.karaf/camel-jfr/${project.version}</bundle>
+    </feature>
     <feature name="camel-jms" version="${project.version}" start-level="50">
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
         <feature version="${camel.osgi.spring.version}">spring-jms</feature>


### PR DESCRIPTION
the dependency tree suggests nothing more than camel-core
```
[INFO] --- maven-dependency-plugin:3.6.1:tree (default-cli) @ camel-jfr ---
[INFO] org.apache.camel:camel-jfr:jar:4.5.1-SNAPSHOT
[INFO] \- org.apache.camel:camel-support:jar:4.5.1-SNAPSHOT:compile
```
but the build fails
`[ERROR] Message: Unable to resolve root: missing requirement [root] osgi.identity; osgi.identity=camel-jfr; type=karaf.feature; version=4.5.0.SNAPSHOT; filter:="(&(osgi.identity=camel-jfr)(type=karaf.feature)(version>=4.5.0.SNAPSHOT))" [caused by: Unable to resolve camel-jfr/4.5.0.SNAPSHOT: missing requirement [camel-jfr/4.5.0.SNAPSHOT] osgi.identity; osgi.identity=camel-jfr; type=osgi.bundle; version="[4.5.0.SNAPSHOT,4.5.0.SNAPSHOT]"; resolution:=mandatory [caused by: Unable to resolve camel-jfr/4.5.0.SNAPSHOT: missing requirement [camel-jfr/4.5.0.SNAPSHOT] osgi.wiring.package; filter:="(osgi.wiring.package=jdk.jfr)"]]`

So excluded the `jdk.jfr` from the component's bundle since the package is a part of the JDK