### PR TITLE
Add camel-aws-xray wrapper

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -472,16 +472,11 @@
 <!--        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>-->
 <!--        <bundle>mvn:org.apache.camel/camel-aws-cloudtrail/${project.version}</bundle>-->
 <!--    </feature>-->
-<!--    <feature name='camel-aws-xray' version='${project.version}' start-level='50'>-->
-<!--        <feature version='${camel.osgi.version.range}'>camel-core</feature>-->
-<!--        <bundle dependency='true'>wrap:mvn:com.amazonaws/aws-xray-recorder-sdk-core/${aws-xray-version}</bundle>-->
-<!--        <bundle dependency='true'>wrap:mvn:com.amazonaws/aws-xray-recorder-sdk-apache-http/${aws-xray-version}</bundle>-->
-<!--        <bundle dependency='true'>wrap:mvn:com.amazonaws/aws-xray-recorder-sdk-aws-sdk/${aws-xray-version}</bundle>-->
-<!--        <bundle dependency='true'>wrap:mvn:com.amazonaws/aws-xray-recorder-sdk-aws-sdk-instrumentor/${aws-xray-version}</bundle>-->
-<!--        <bundle dependency='true'>wrap:mvn:com.amazonaws/aws-xray-recorder-sdk-sql-postgres/${aws-xray-version}</bundle>-->
-<!--        <bundle dependency='true'>wrap:mvn:com.amazonaws/aws-xray-recorder-sdk-sql-mysql/${aws-xray-version}</bundle>-->
-<!--        <bundle>mvn:org.apache.camel/camel-aws-xray/${project.version}</bundle>-->
-<!--    </feature>-->
+    <feature name='camel-aws-xray' version='${project.version}' start-level='50'>
+        <feature version='${camel.osgi.version.range}'>camel-core</feature>
+        <bundle dependency='true'>wrap:mvn:com.amazonaws/aws-xray-recorder-sdk-core/${aws-xray-version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-aws-xray/${project.version}</bundle>
+    </feature>
     <feature name='camel-azure-storage-blob' version='${project.version}' start-level='50'>
         <feature version='${camel.osgi.version.range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>


### PR DESCRIPTION
Only `com.amazonaws/aws-xray-recorder-sdk-core` was needed at build time, however dependency tree suggests other xray libraries
```
[INFO] org.apache.camel:camel-aws-xray:jar:4.5.1-SNAPSHOT
[INFO] +- org.apache.camel:camel-core-engine:jar:4.5.1-SNAPSHOT:compile
[INFO] |  +- org.apache.camel:camel-api:jar:4.5.1-SNAPSHOT:compile
[INFO] |  |  \- jakarta.xml.bind:jakarta.xml.bind-api:jar:4.0.2:compile
[INFO] |  |     \- jakarta.activation:jakarta.activation-api:jar:2.1.3:compile
[INFO] |  +- org.apache.camel:camel-base-engine:jar:4.5.1-SNAPSHOT:compile
[INFO] |  |  \- org.apache.camel:camel-base:jar:4.5.1-SNAPSHOT:compile
[INFO] |  +- org.apache.camel:camel-core-reifier:jar:4.5.1-SNAPSHOT:compile
[INFO] |  |  +- org.apache.camel:camel-core-model:jar:4.5.1-SNAPSHOT:compile
[INFO] |  |  \- org.apache.camel:camel-core-processor:jar:4.5.1-SNAPSHOT:compile
[INFO] |  +- org.apache.camel:camel-management-api:jar:4.5.1-SNAPSHOT:compile
[INFO] |  +- org.apache.camel:camel-support:jar:4.5.1-SNAPSHOT:compile
[INFO] |  |  +- org.apache.camel:camel-util-json:jar:4.5.1-SNAPSHOT:compile
[INFO] |  |  \- org.apache.camel:camel-xml-jaxp-util:jar:4.5.1-SNAPSHOT:compile
[INFO] |  \- org.apache.camel:camel-util:jar:4.5.1-SNAPSHOT:compile
[INFO] +- org.apache.camel:camel-bean:jar:4.5.1-SNAPSHOT:compile
[INFO] +- com.amazonaws:aws-xray-recorder-sdk-core:jar:2.15.1:compile
[INFO] |  \- com.amazonaws:aws-java-sdk-xray:jar:1.12.228:compile
[INFO] |     \- com.amazonaws:jmespath-java:jar:1.12.228:compile
[INFO] +- com.amazonaws:aws-xray-recorder-sdk-aws-sdk:jar:2.15.1:compile
[INFO] |  +- com.amazonaws:aws-java-sdk-core:jar:1.12.228:compile
[INFO] |  |  +- commons-logging:commons-logging:jar:1.1.3:compile
[INFO] |  |  +- commons-codec:commons-codec:jar:1.16.1:compile
[INFO] |  |  +- software.amazon.ion:ion-java:jar:1.0.2:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile
[INFO] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.16.2:compile
[INFO] |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.16.2:compile
[INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.16.2:compile
[INFO] |  |  \- joda-time:joda-time:jar:2.8.1:compile
[INFO] |  \- com.amazonaws:aws-xray-recorder-sdk-aws-sdk-core:jar:2.15.1:runtime
[INFO] \- com.amazonaws:aws-xray-recorder-sdk-apache-http:jar:2.15.1:compile
[INFO]    \- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
[INFO]       \- org.apache.httpcomponents:httpcore:jar:4.4.13:compile
```
